### PR TITLE
fix: ensure semanticdb version is pulled from scalafix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies._
 
-val scala2 = "2.13.6"
+val scala2 = "2.13.8"
 val scala3 = "3.1.1"
 
 ThisBuild / scalaVersion := scala2
@@ -28,6 +28,7 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 
 Compile / run / fork := true
 Global / semanticdbEnabled := true
+Global / semanticdbVersion := scalafixSemanticdb.revision
 
 def avro4sDep(scalaVersion: String, scope: String = Provided.toString): List[ModuleID] =
   CrossVersion.partialVersion(scalaVersion) match {


### PR DESCRIPTION
Since you're using `Global / semanticdbEnabled := true` this tells sbt
to automatically include the semanticdb compiler plugin. This can be out
of date, even in the newest sbt versions. You can see the version by
doing an `sbt semanticdbVersion`. Without the change I made here it will
default to 4.4.28, which isn't published for 2.13.8, which is why the
build failed before.

This change adds in a small fix to instead pull the `semanticdbVersion`
from the Scalafix plugin which is used, which is why you have this
setting in the first place. This will ensure that as a new Scala version
comes out, you bump scalafix, which will also bump your
semanticdbVersion.

Closes #1 