### PR TITLE
producer: remove name requirement for deduplication

### DIFF
--- a/core/src/main/scala/dev/profunktor/pulsar/Producer.scala
+++ b/core/src/main/scala/dev/profunktor/pulsar/Producer.scala
@@ -274,6 +274,7 @@ object Producer {
     val unsafeOps: ProducerBuilder[Any] => ProducerBuilder[Any]
     def withBatching(_batching: Batching): Settings[F, E]
     def withMessageKey(_msgKey: E => MessageKey): Settings[F, E]
+    def withName(_name: String): Settings[F, E]
     def withShardKey(_shardKey: E => ShardKey): Settings[F, E]
     def withLogger(_logger: E => Topic.URL => F[Unit]): Settings[F, E]
 
@@ -286,10 +287,10 @@ object Producer {
       *
       * {{{
       *  Producer.Settings[IO, String]()
-      *     .withDeduplication(SeqIdMaker.fromEq[String], "producer-name-1")
+      *     .withDeduplication(SeqIdMaker.fromEq[String])
       * }}}
       */
-    def withDeduplication(seqIdMaker: SeqIdMaker[E], name: String): Settings[F, E]
+    def withDeduplication(seqIdMaker: SeqIdMaker[E]): Settings[F, E]
 
     /**
       * USE THIS ONE WITH CAUTION!
@@ -327,13 +328,12 @@ object Producer {
         deduplication: Deduplication[E],
         unsafeOps: ProducerBuilder[Any] => ProducerBuilder[Any]
     ) extends Settings[F, E] {
+      override def withName(_name: String): Settings[F, E] =
+        copy(name = Some(_name))
       override def withBatching(_batching: Batching): Settings[F, E] =
         copy(batching = _batching)
-      override def withDeduplication(
-          seqIdMaker: SeqIdMaker[E],
-          _name: String
-      ): Settings[F, E] =
-        copy(deduplication = Deduplication.Enabled(seqIdMaker), name = Some(_name))
+      override def withDeduplication(seqIdMaker: SeqIdMaker[E]): Settings[F, E] =
+        copy(deduplication = Deduplication.Enabled(seqIdMaker))
       override def withMessageKey(_msgKey: E => MessageKey): Settings[F, E] =
         copy(messageKey = _msgKey)
       override def withShardKey(_shardKey: E => ShardKey): Settings[F, E] =

--- a/docs/src/paradox/reference/Producer.md
+++ b/docs/src/paradox/reference/Producer.md
@@ -93,7 +93,7 @@ This instance is usually good enough, as Pulsar only requires the next sequence 
 To enable deduplication, we can use the following setting.
 
 ```scala mdoc
-Producer.Settings[IO, String]().withDeduplication(seqIdMaker, "producer-name-1")
+Producer.Settings[IO, String]().withDeduplication(seqIdMaker)
 ```
 
 The [DeduplicationSuite](https://github.com/profunktor/neutron/blob/main/tests/src/it/scala/dev/profunktor/pulsar/DeduplicationSuite.scala) showcases this feature (also see the `run.sh` script, where deduplication is enabled at the topic level).

--- a/tests/src/it/scala/dev/profunktor/pulsar/DeduplicationSuite.scala
+++ b/tests/src/it/scala/dev/profunktor/pulsar/DeduplicationSuite.scala
@@ -48,7 +48,7 @@ object DeduplicationSuite extends IOSuite {
   val pSettings =
     Producer
       .Settings[IO, String]()
-      .withDeduplication(SeqIdMaker.fromEq[String], name = "dedup-prod-1")
+      .withDeduplication(SeqIdMaker.fromEq[String])
 
   def showStats(s: ProducerStats): IO[Unit] = IO.println {
     s"""


### PR DESCRIPTION
Pulsar generates a globally unique producer name if we do not set one, so deduplication will still work.