### PR TITLE
consumer: unsafe operations

### DIFF
--- a/docs/src/paradox/reference/Transactions.md
+++ b/docs/src/paradox/reference/Transactions.md
@@ -34,7 +34,7 @@ Next, we can create a transactional resource.
 
 ```scala mdoc
 import scala.concurrent.duration._
-import dev.profunktor.pulsar.transactions.{ PulsarTx, Tx }
+import dev.profunktor.pulsar.transactions.PulsarTx
 
 mkClient.use { cli =>
   val mkTx = PulsarTx.make[IO](


### PR DESCRIPTION
The premise is simple: allow users to execute operations on the underlying Java Consumer whenever this library does not support it. 

In any case, if you find yourself using an `unsafe` operation regularly, it would be best to submit a feature request issue to this repository, or even better, submit a PR adding support for the operation you need.