### PR TITLE
consumer: expose underlying raw message

### DIFF
--- a/core/src/main/scala/dev/profunktor/pulsar/Consumer.scala
+++ b/core/src/main/scala/dev/profunktor/pulsar/Consumer.scala
@@ -151,8 +151,8 @@ private abstract class SchemaConsumer[F[_]: FutureLift: Sync, E](
                     m.getMessageId,
                     MessageKey(m.getKey),
                     m.getProperties.asScala.toMap,
-                    e,
-                    m.asInstanceOf[JMessage[Any]]
+                    m.asInstanceOf[JMessage[Any]],
+                    e
                   )
                 )
           }
@@ -187,8 +187,8 @@ private abstract class ByteConsumer[F[_]: FutureLift: Sync, E](
                           m.getMessageId,
                           MessageKey(m.getKey),
                           m.getProperties.asScala.toMap,
-                          e,
-                          m.asInstanceOf[JMessage[Any]]
+                          m.asInstanceOf[JMessage[Any]],
+                          e
                         )
                       )
                 }
@@ -211,8 +211,8 @@ object Consumer {
       id: MessageId,
       key: MessageKey,
       properties: Map[String, String],
-      payload: A,
-      raw: JMessage[Any]
+      raw: JMessage[Any],
+      payload: A
   )
 
   case class DecodingFailure(msg: String) extends Exception(msg) with NoStackTrace

--- a/core/src/main/scala/dev/profunktor/pulsar/Consumer.scala
+++ b/core/src/main/scala/dev/profunktor/pulsar/Consumer.scala
@@ -28,7 +28,7 @@ import cats._
 import cats.effect._
 import cats.syntax.all._
 import fs2._
-import org.apache.pulsar.client.api.{ Consumer => JConsumer, _ }
+import org.apache.pulsar.client.api.{ Consumer => JConsumer, Message => JMessage, _ }
 
 trait Consumer[F[_], E] {
 
@@ -151,7 +151,8 @@ private abstract class SchemaConsumer[F[_]: FutureLift: Sync, E](
                     m.getMessageId,
                     MessageKey(m.getKey),
                     m.getProperties.asScala.toMap,
-                    e
+                    e,
+                    m.asInstanceOf[JMessage[Any]]
                   )
                 )
           }
@@ -186,7 +187,8 @@ private abstract class ByteConsumer[F[_]: FutureLift: Sync, E](
                           m.getMessageId,
                           MessageKey(m.getKey),
                           m.getProperties.asScala.toMap,
-                          e
+                          e,
+                          m.asInstanceOf[JMessage[Any]]
                         )
                       )
                 }
@@ -209,7 +211,8 @@ object Consumer {
       id: MessageId,
       key: MessageKey,
       properties: Map[String, String],
-      payload: A
+      payload: A,
+      raw: JMessage[Any]
   )
 
   case class DecodingFailure(msg: String) extends Exception(msg) with NoStackTrace

--- a/docs/src/paradox/reference/Consumer.md
+++ b/docs/src/paradox/reference/Consumer.md
@@ -15,8 +15,8 @@ object Consumer {
       id: MessageId,
       key: MessageKey,
       properties: Map[String, String],
-      payload: A,
-      raw: JMessage[Any]
+      raw: JMessage[Any],
+      payload: A
   )
 }
 
@@ -152,7 +152,7 @@ def manual(
 ): IO[Unit] =
   consumer
    .subscribe
-   .evalMap { case Consumer.Message(id, _, _, payload, _) =>
+   .evalMap { case Consumer.Message(id, _, _, _, payload) =>
      process(payload) // pretend `process` might raise an error
        .flatMap(_ => consumer.ack(id))
        .handleErrorWith(e => IO.println(e) *> consumer.nack(id))

--- a/docs/src/paradox/reference/Consumer.md
+++ b/docs/src/paradox/reference/Consumer.md
@@ -8,14 +8,15 @@ Neutron models it via a tagless algebra.
 import dev.profunktor.pulsar._
 
 import fs2.Stream
-import org.apache.pulsar.client.api.MessageId
+import org.apache.pulsar.client.api.{ Message => JMessage, MessageId }
 
 object Consumer {
   case class Message[A](
       id: MessageId,
       key: MessageKey,
       properties: Map[String, String],
-      payload: A
+      payload: A,
+      raw: JMessage[Any]
   )
 }
 
@@ -151,7 +152,7 @@ def manual(
 ): IO[Unit] =
   consumer
    .subscribe
-   .evalMap { case Consumer.Message(id, _, _, payload) =>
+   .evalMap { case Consumer.Message(id, _, _, payload, _) =>
      process(payload) // pretend `process` might raise an error
        .flatMap(_ => consumer.ack(id))
        .handleErrorWith(e => IO.println(e) *> consumer.nack(id))

--- a/tests/src/it/scala/dev/profunktor/pulsar/DeduplicationSuite.scala
+++ b/tests/src/it/scala/dev/profunktor/pulsar/DeduplicationSuite.scala
@@ -76,7 +76,7 @@ object DeduplicationSuite extends IOSuite {
             case (c, p) =>
               val consume =
                 c.subscribe.evalMap {
-                  case Consumer.Message(id, _, _, payload) =>
+                  case Consumer.Message(id, _, _, _, payload) =>
                     for {
                       _ <- ref.update(_ :+ payload)
                       _ <- c.ack(id)

--- a/tests/src/it/scala/dev/profunktor/pulsar/PulsarSuite.scala
+++ b/tests/src/it/scala/dev/profunktor/pulsar/PulsarSuite.scala
@@ -119,7 +119,7 @@ object PulsarSuite extends IOSuite {
           case (consumer, producer) =>
             val consume =
               consumer.subscribe.evalMap {
-                case Consumer.Message(id, _, props, payload) =>
+                case Consumer.Message(id, _, props, _, payload) =>
                   consumer.ack(id) *> latch.complete(payload -> props)
               }
 

--- a/tests/src/it/scala/dev/profunktor/pulsar/TransactionSuite.scala
+++ b/tests/src/it/scala/dev/profunktor/pulsar/TransactionSuite.scala
@@ -92,7 +92,7 @@ object TransactionSuite extends IOSuite {
               Stream.resource(mkTx).flatMap { tx =>
                 val consumeInputs =
                   ci.subscribe.evalMap {
-                    case Consumer.Message(id, _, _, payload) =>
+                    case Consumer.Message(id, _, _, _, payload) =>
                       for {
                         _ <- ref.update(_ :+ payload)
                         _ <- ids.update(_ + id)
@@ -102,7 +102,7 @@ object TransactionSuite extends IOSuite {
 
                 val consumeOutputs =
                   co.subscribe.evalMap {
-                    case Consumer.Message(id, _, _, payload) =>
+                    case Consumer.Message(id, _, _, _, payload) =>
                       ref.update(_ :+ payload) *> co.ack(id) *>
                           latch.complete(()).whenA(payload == "c-out")
                   }


### PR DESCRIPTION
Needed for operations such as `reconsumerLater`.