### PR TITLE
fix deduplication id generation interface

### DIFF
--- a/core/src/main/scala/dev/profunktor/pulsar/Producer.scala
+++ b/core/src/main/scala/dev/profunktor/pulsar/Producer.scala
@@ -66,10 +66,10 @@ object Producer {
     case object Disabled extends Batching
   }
 
-  sealed trait Deduplication[+A]
+  sealed trait Deduplication[F[_]]
   object Deduplication {
-    case object Disabled extends Deduplication[Nothing]
-    case class Enabled[A](seqIdMaker: SeqIdMaker[A]) extends Deduplication[A]
+    case class Disabled[F[_]]() extends Deduplication[F]
+    case class Enabled[F[_]](seqIdMaker: SeqIdMaker[F]) extends Deduplication[F]
   }
 
   /**
@@ -145,7 +145,7 @@ object Producer {
         builder: ProducerBuilder[A]
     ): ProducerBuilder[A] =
       settings.deduplication match {
-        case Deduplication.Disabled   => builder
+        case Deduplication.Disabled() => builder
         case Deduplication.Enabled(_) => builder.sendTimeout(0, TimeUnit.SECONDS)
       }
 
@@ -167,8 +167,7 @@ object Producer {
         p: JProducer[A],
         msg: E,
         enc: E => A,
-        properties: Map[String, String],
-        prevMsgs: Ref[F, Option[E]]
+        properties: Map[String, String]
     ): F[MessageId] = {
       val _msg = enc(msg)
 
@@ -186,13 +185,10 @@ object Producer {
 
       settings.deduplication match {
         case Deduplication.Enabled(seqIdMaker) =>
-          prevMsgs.modify { prev =>
-            val nextId = seqIdMaker
-              .asInstanceOf[SeqIdMaker[E]]
-              .next(p.getLastSequenceId(), prev, msg)
-            Some(msg) -> cont(_.sequenceId(nextId))
-          }.flatten
-        case Deduplication.Disabled =>
+          seqIdMaker.make(p.getLastSequenceId()).flatMap { nextId =>
+            cont(_.sequenceId(nextId))
+          }
+        case Deduplication.Disabled() =>
           cont(identity)
       }
     }
@@ -212,16 +208,15 @@ object Producer {
           }
         }
       }(p => FutureLift[F].futureLift(p.fold(_.closeAsync(), _.closeAsync())).void)
-      .evalMap(p => Ref.of[F, Option[E]](None).map(p -> _))
       .map {
-        case (Left(p), prevMsgs) =>
+        case Left(p) =>
           new Producer[F, E] {
             override def send(msg: E): F[MessageId] = send(msg, Map.empty)
 
             override def send_(msg: E): F[Unit] = send(msg).void
 
             override def send(msg: E, properties: Map[String, String]): F[MessageId] =
-              sendMessage[E](p, msg, identity, properties, prevMsgs)
+              sendMessage[E](p, msg, identity, properties)
 
             override def send_(msg: E, properties: Map[String, String]): F[Unit] =
               send(msg, properties).void
@@ -230,7 +225,7 @@ object Producer {
               Sync[F].blocking(p.getStats())
           }
 
-        case (Right(p), prevMsgs) =>
+        case Right(p) =>
           settings.messageEncoder.fold(
             throw new IllegalArgumentException(
               "Missing message encoder (used when pulsar schema is not set)"
@@ -242,7 +237,7 @@ object Producer {
               override def send_(msg: E): F[Unit] = send(msg).void
 
               override def send(msg: E, properties: Map[String, String]): F[MessageId] =
-                sendMessage[Array[Byte]](p, msg, enc, properties, prevMsgs)
+                sendMessage[Array[Byte]](p, msg, enc, properties)
 
               override def send_(msg: E, properties: Map[String, String]): F[Unit] =
                 send(msg, properties).void
@@ -263,7 +258,7 @@ object Producer {
     val logger: E => Topic.URL => F[Unit]
     val messageEncoder: Option[E => Array[Byte]]
     val schema: Option[Schema[E]]
-    val deduplication: Deduplication[E]
+    val deduplication: Deduplication[F]
     val unsafeOps: ProducerBuilder[Any] => ProducerBuilder[Any]
     def withBatching(_batching: Batching): Settings[F, E]
     def withMessageKey(_msgKey: E => MessageKey): Settings[F, E]
@@ -279,11 +274,14 @@ object Producer {
       * Example:
       *
       * {{{
-      *  Producer.Settings[IO, String]()
-      *     .withDeduplication(SeqIdMaker.fromEq[String])
+      *  val maker = SeqIdMaker.instance[IO](
+      *    lastSeqId => IO.pure(lastSeqId + 1)
+      *  )
+      *
+      *  Producer.Settings[IO, String]().withDeduplication(maker)
       * }}}
       */
-    def withDeduplication(seqIdMaker: SeqIdMaker[E]): Settings[F, E]
+    def withDeduplication(seqIdMaker: SeqIdMaker[F]): Settings[F, E]
 
     /**
       * USE THIS ONE WITH CAUTION!
@@ -318,14 +316,14 @@ object Producer {
         logger: E => Topic.URL => F[Unit],
         messageEncoder: Option[E => Array[Byte]],
         schema: Option[Schema[E]],
-        deduplication: Deduplication[E],
+        deduplication: Deduplication[F],
         unsafeOps: ProducerBuilder[Any] => ProducerBuilder[Any]
     ) extends Settings[F, E] {
       override def withName(_name: String): Settings[F, E] =
         copy(name = Some(_name))
       override def withBatching(_batching: Batching): Settings[F, E] =
         copy(batching = _batching)
-      override def withDeduplication(seqIdMaker: SeqIdMaker[E]): Settings[F, E] =
+      override def withDeduplication(seqIdMaker: SeqIdMaker[F]): Settings[F, E] =
         copy(deduplication = Deduplication.Enabled(seqIdMaker))
       override def withMessageKey(_msgKey: E => MessageKey): Settings[F, E] =
         copy(messageKey = _msgKey)
@@ -353,7 +351,7 @@ object Producer {
         logger = _ => _ => Applicative[F].unit,
         messageEncoder = None,
         schema = None,
-        deduplication = Deduplication.Disabled,
+        deduplication = Deduplication.Disabled[F](),
         unsafeOps = identity
       )
   }

--- a/core/src/main/scala/dev/profunktor/pulsar/SeqIdMaker.scala
+++ b/core/src/main/scala/dev/profunktor/pulsar/SeqIdMaker.scala
@@ -16,43 +16,24 @@
 
 package dev.profunktor.pulsar
 
-import cats.kernel.Eq
-import cats.syntax.eq._
-
 /**
   * Dictates how `sequenceId`s (used for deduplication) are generated based on:
   *
   * - A previous sequence id (-1 if there are no previous messages).
-  * - A previous payload (message).
-  * - A new payload.
   *
-  * An instance has to be contructed explicitly and pass it to `withDeduplication`
-  * in the producer settings. It could be a typeclass but it makes things awkward
-  * when deduplication is not required.
-  *
-  * You can either build one via either the `fromEq` or the `instance` constructors.
+  * Users are responsible for keeping track of their messages, and return (lastSeqId + 1) when
+  * the message is unique, or simply `lastSeqId` when it's a duplicate.
   */
-trait SeqIdMaker[A] {
-  def next(prevId: Long, prevPayload: Option[A], payload: A): Long
+trait SeqIdMaker[F[_]] {
+  def make(lastSeqId: Long): F[Long]
 }
 
 object SeqIdMaker {
 
   /**
-    * Creates an instance using the given Eq[A] instance to determine whether
-    * two values of type A are equal.
+    * Creates an instance using the given 'make' function'.
     */
-  def fromEq[A: Eq]: SeqIdMaker[A] = new SeqIdMaker[A] {
-    def next(prevId: Long, prevPayload: Option[A], payload: A): Long =
-      prevPayload match {
-        case Some(p) if p === payload => prevId
-        case _                        => prevId + 1L
-      }
+  def instance[F[_]](f: Long => F[Long]): SeqIdMaker[F] = new SeqIdMaker[F] {
+    def make(lastSeqId: Long): F[Long] = f(lastSeqId)
   }
-
-  /**
-    * Creates an instance using the comparison function to determine whether
-    * two values of type A are equal.
-    */
-  def instance[A](f: (A, A) => Boolean): SeqIdMaker[A] = fromEq[A](Eq.instance(f))
 }

--- a/docs/src/paradox/reference/Producer.md
+++ b/docs/src/paradox/reference/Producer.md
@@ -77,8 +77,8 @@ In a nutshell, the deduplication mechanism is based on sequence ids, which can b
 To make things smoother, Neutron internally manages the creation of new sequence ids via the following interface.
 
 ```scala mdoc
-trait SeqIdMaker[F[_]] {
-  def make(lastSeqId: Long): F[Long]
+trait SeqIdMaker[F[_], A] {
+  def make(lastSeqId: Long, currentMsg: A): F[Long]
 }
 ```
 
@@ -87,8 +87,9 @@ Users are responsible for keeping track of their messages (usually by an `EventI
 You may use the `instance` constructor as follows:
 
 ```scala mdoc
-val seqIdMaker = SeqIdMaker.instance[IO] { lastSeqId =>
-  IO.pure(lastSeqId + 1) // replace with your logic
+val seqIdMaker = SeqIdMaker.instance[IO, String] { (lastSeqId, msg) =>
+  // use `msg` to compare it to previous messages and determine SeqId
+  IO.pure(lastSeqId + 1)
 }
 ```
 

--- a/tests/src/it/scala/dev/profunktor/pulsar/DeduplicationSuite.scala
+++ b/tests/src/it/scala/dev/profunktor/pulsar/DeduplicationSuite.scala
@@ -45,10 +45,17 @@ object DeduplicationSuite extends IOSuite {
 
   val utf8 = PulsarSchema.utf8
 
-  val pSettings =
-    Producer
-      .Settings[IO, String]()
-      .withDeduplication(SeqIdMaker.fromEq[String])
+  def mkSeqIdMaker: IO[SeqIdMaker[IO, String]] =
+    Ref.of[IO, Seq[String]](Seq.empty).map { ref =>
+      SeqIdMaker.instance { (lastSeqId, msg) =>
+        ref.getAndUpdate(_ +: msg).map { xs =>
+          if (xs.contains(msg)) lastSeqId else lastSeqId + 1
+        }
+      }
+    }
+
+  def pSettings(seqIdMaker: SeqIdMaker[IO, String]) =
+    Producer.Settings[IO, String]().withDeduplication(seqIdMaker)
 
   def showStats(s: ProducerStats): IO[Unit] = IO.println {
     s"""
@@ -64,7 +71,8 @@ object DeduplicationSuite extends IOSuite {
   test("Producer deduplicates messages") { client =>
     val res: Resource[IO, (Consumer[IO, String], Producer[IO, String])] =
       for {
-        p <- Producer.make[IO, String](client, topic, utf8, pSettings)
+        m <- Resource.eval(mkSeqIdMaker)
+        p <- Producer.make[IO, String](client, topic, utf8, pSettings(m))
         c <- Consumer.make[IO, String](client, topic, sub, utf8)
       } yield c -> p
 

--- a/tests/src/it/scala/dev/profunktor/pulsar/DeduplicationSuite.scala
+++ b/tests/src/it/scala/dev/profunktor/pulsar/DeduplicationSuite.scala
@@ -48,7 +48,7 @@ object DeduplicationSuite extends IOSuite {
   def mkSeqIdMaker: IO[SeqIdMaker[IO, String]] =
     Ref.of[IO, Seq[String]](Seq.empty).map { ref =>
       SeqIdMaker.instance { (lastSeqId, msg) =>
-        ref.getAndUpdate(_ +: msg).map { xs =>
+        ref.getAndUpdate(_ :+ msg).map { xs =>
           if (xs.contains(msg)) lastSeqId else lastSeqId + 1
         }
       }


### PR DESCRIPTION
Comparing a message to *only* a previous message was wrong, as a message could be redelivered a few seconds or minutes later.