### PR TITLE
Major dependency upgrades

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 
-val scala2 = "2.13.10"
-val scala3 = "3.2.2"
+val scala2 = "2.13.11"
+val scala3 = "3.3.0"
 
 ThisBuild / scalaVersion := scala2
 ThisBuild / organization := "dev.profunktor"
@@ -22,11 +22,12 @@ ThisBuild / developers := List(
   )
 )
 
-ThisBuild / scalafixDependencies += Libraries.organizeImports
+ThisBuild / evictionErrorLevel := Level.Info
 
 resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 Compile / run / fork := true
+Global / onChangedBuildSource := ReloadOnSourceChanges
 Global / semanticdbEnabled := true
 Global / semanticdbVersion := scalafixSemanticdb.revision
 
@@ -171,4 +172,4 @@ lazy val root = (project in file("."))
     tests
   )
 
-addCommandAlias("runLinter", ";scalafixAll --rules OrganizeImports")
+addCommandAlias("lint", "; scalafmtAll; scalafixAll --rules OrganizeImports")

--- a/core/src/main/scala/dev/profunktor/pulsar/Config.scala
+++ b/core/src/main/scala/dev/profunktor/pulsar/Config.scala
@@ -46,7 +46,7 @@ object Config {
     type Mandatory = Empty with Namespace with Tenant with URL
   }
 
-  case class ConfigBuilder[I <: Info] protected (
+  case class ConfigBuilder[I <: Info] private[pulsar] (
       _tenant: PulsarTenant = PulsarTenant(""),
       _namespace: PulsarNamespace = PulsarNamespace(""),
       _url: PulsarURL = PulsarURL("")

--- a/core/src/main/scala/dev/profunktor/pulsar/Consumer.scala
+++ b/core/src/main/scala/dev/profunktor/pulsar/Consumer.scala
@@ -285,7 +285,10 @@ object Consumer {
             override def nack(id: MessageId): F[Unit] =
               Sync[F].blocking(c.negativeAcknowledge(id))
             override def lastMessageId: F[Option[MessageId]] =
-              F.futureLift(c.getLastMessageIdAsync()).attempt.map(_.toOption)
+              F.futureLift(c.getLastMessageIdsAsync())
+                .map(_.asScala.toList.filter(_.getOwnerTopic() == topic.show).headOption)
+                .attempt
+                .map(_.toOption.flatten)
             override def unsubscribe: F[Unit] =
               F.futureLift(c.unsubscribeAsync()).void
             override def subscribe: Stream[F, Message[E]] =
@@ -318,7 +321,12 @@ object Consumer {
               override def nack(id: MessageId): F[Unit] =
                 Sync[F].blocking(c.negativeAcknowledge(id))
               override def lastMessageId: F[Option[MessageId]] =
-                F.futureLift(c.getLastMessageIdAsync()).attempt.map(_.toOption)
+                F.futureLift(c.getLastMessageIdsAsync())
+                  .map(
+                    _.asScala.toList.filter(_.getOwnerTopic() == topic.show).headOption
+                  )
+                  .attempt
+                  .map(_.toOption.flatten)
               override def unsubscribe: F[Unit] =
                 F.futureLift(c.unsubscribeAsync()).void
               override def subscribe: Stream[F, Message[E]] =

--- a/core/src/main/scala/dev/profunktor/pulsar/Reader.scala
+++ b/core/src/main/scala/dev/profunktor/pulsar/Reader.scala
@@ -26,12 +26,7 @@ import cats.Functor
 import cats.effect._
 import cats.syntax.all._
 import fs2._
-import org.apache.pulsar.client.api.{
-  MessageId,
-  Reader => JReader,
-  ReaderBuilder,
-  Schema
-}
+import org.apache.pulsar.client.api.{ Reader => JReader, _ }
 
 /**
   * A MessageReader can be used to read all the messages currently available in a topic.

--- a/core/src/main/scala/dev/profunktor/pulsar/Subscription.scala
+++ b/core/src/main/scala/dev/profunktor/pulsar/Subscription.scala
@@ -84,7 +84,7 @@ object Subscription {
     type Mandatory = Empty with Name with Mode with Type
   }
 
-  case class SubscriptionBuilder[I <: Info] protected (
+  case class SubscriptionBuilder[I <: Info] private[pulsar] (
       _name: Name = Name(""),
       _type: Type = Type.Exclusive,
       _mode: Mode = Mode.Durable

--- a/core/src/main/scala/dev/profunktor/pulsar/Topic.scala
+++ b/core/src/main/scala/dev/profunktor/pulsar/Topic.scala
@@ -89,7 +89,7 @@ object Topic {
     type MultiMandatory  = Empty with Config with Pattern with Type
   }
 
-  case class TopicBuilder[I <: Info] protected (
+  case class TopicBuilder[I <: Info] private[pulsar] (
       _name: Either[Name, NamePattern] = Name("").asLeft,
       _config: Config = Config.Builder.default,
       _type: Type = Type.Persistent

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   pulsar:
     restart: always
-    image: apachepulsar/pulsar:2.11.0
+    image: apachepulsar/pulsar:3.1.0
     ports:
       - "6650:6650"
       - "8080:8080"

--- a/function/src/test/scala/dev/profunktor/pulsar/FunctionInput.scala
+++ b/function/src/test/scala/dev/profunktor/pulsar/FunctionInput.scala
@@ -25,13 +25,13 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.pulsar.client.admin.PulsarAdmin
 import org.apache.pulsar.client.api.{ ConsumerBuilder, Schema, TypedMessageBuilder }
+import org.apache.pulsar.functions.api.utils.FunctionRecord
 import org.apache.pulsar.functions.api.{
   Context => JavaContext,
   Record => JavaRecord,
-  StateStore,
-  WindowContext => JavaWindowContext
+  WindowContext => JavaWindowContext,
+  _
 }
-import org.apache.pulsar.functions.api.utils.FunctionRecord
 import org.slf4j.Logger
 
 object FunctionInput {

--- a/function/src/test/scala/dev/profunktor/pulsar/WindowContextSuite.scala
+++ b/function/src/test/scala/dev/profunktor/pulsar/WindowContextSuite.scala
@@ -21,6 +21,7 @@ import java.util
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
 
+import scala.annotation.nowarn
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -35,6 +36,7 @@ import org.slf4j.Logger
 import weaver.SimpleIOSuite
 import weaver.scalacheck.Checkers
 
+@nowarn
 object WindowContextSuite extends SimpleIOSuite with Checkers {
   test("WindowContext mapping of fields is correct") {
     forall {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,11 +5,11 @@ object Dependencies {
   object V {
     val avro4s_2   = "4.1.1"
     val avro4s_3   = "5.0.5"
-    val cats       = "2.9.0"
+    val cats       = "2.10.0"
     val catsEffect = "3.5.1"
     val circe      = "0.14.6"
-    val fs2        = "3.6.1"
-    val pulsar     = "2.11.2"
+    val fs2        = "3.9.1"
+    val pulsar     = "3.1.0"
     val weaver     = "0.8.3"
 
     val kindProjector   = "0.13.2"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,15 @@
-addSbtPlugin("com.github.sbt"            % "sbt-ci-release"             % "1.5.10")
-addSbtPlugin("de.heikoseeberger"         % "sbt-header"                 % "5.9.0")
-addSbtPlugin("io.spray"                  % "sbt-revolver"               % "0.9.1")
+ThisBuild / libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+)
+
+addSbtPlugin("com.github.sbt"            % "sbt-ci-release"             % "1.5.12")
+addSbtPlugin("de.heikoseeberger"         % "sbt-header"                 % "5.10.0")
+addSbtPlugin("io.spray"                  % "sbt-revolver"               % "0.10.0")
 addSbtPlugin("org.scalameta"             % "sbt-scalafmt"               % "2.5.2")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"               % "0.4.1")
-addSbtPlugin("com.typesafe.sbt"          % "sbt-ghpages"                % "0.6.3")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"               % "0.4.4")
+addSbtPlugin("com.github.sbt"            % "sbt-ghpages"                % "0.8.0")
 addSbtPlugin("org.scalameta"             % "sbt-mdoc"                   % "2.3.7")
 addSbtPlugin("com.lightbend.paradox"     % "sbt-paradox"                % "0.10.3")
 addSbtPlugin("io.github.jonas"           % "sbt-paradox-material-theme" % "0.6.0")
 addSbtPlugin("com.typesafe.sbt"          % "sbt-site"                   % "1.3.3")
-addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix"               % "0.10.4")
+addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix"               % "0.11.0")

--- a/tests/src/it/scala/dev/profunktor/pulsar/AlwaysIncompatibleSchemaSuite.scala
+++ b/tests/src/it/scala/dev/profunktor/pulsar/AlwaysIncompatibleSchemaSuite.scala
@@ -60,11 +60,10 @@ object AlwaysIncompatibleSchemaSuite extends IOSuite {
         consumer <- Consumer.make[IO, Event](client, topic, sub("circe"), schema)
       } yield consumer -> producer
 
-    ignore("FIXME: Not working on Scala 3") >>
-      res.attempt.use {
-        case Left(_: IncompatibleSchemaException) => IO.pure(success)
-        case _                                    => IO(failure("Expected IncompatibleSchemaException"))
-      }
+    res.attempt.use {
+      case Left(_: IncompatibleSchemaException) => IO.pure(success)
+      case _                                    => IO(failure("Expected IncompatibleSchemaException"))
+    }
   }
 
 }

--- a/tests/src/it/scala/dev/profunktor/pulsar/BackwardCompatSchemaSuite.scala
+++ b/tests/src/it/scala/dev/profunktor/pulsar/BackwardCompatSchemaSuite.scala
@@ -64,7 +64,7 @@ object BackwardCompatSchemaSuite extends IOSuite {
           consumer <- Consumer.make[IO, Event_V2](client, topic, sub("circe"), schema_v2)
         } yield consumer -> producer
 
-      ignore("FIXME: Not working on Scala 3") >> (
+      ignore("FIXME: Figure out why this doesn't work after upgrading to Scala 3") >> (
         Ref.of[IO, Int](0),
         Deferred[IO, Event_V2]
       ).tupled.flatMap {

--- a/tests/src/it/scala/dev/profunktor/pulsar/BackwardCompatSchemaSuite.scala
+++ b/tests/src/it/scala/dev/profunktor/pulsar/BackwardCompatSchemaSuite.scala
@@ -64,7 +64,7 @@ object BackwardCompatSchemaSuite extends IOSuite {
           consumer <- Consumer.make[IO, Event_V2](client, topic, sub("circe"), schema_v2)
         } yield consumer -> producer
 
-      ignore("FIXME: Figure out why this doesn't work after upgrading to Scala 3") >> (
+      (
         Ref.of[IO, Int](0),
         Deferred[IO, Event_V2]
       ).tupled.flatMap {


### PR DESCRIPTION
# Summary

- Scala 3.3.0 and 2.13.11
- Pulsar Cilent 3.1.0
- Fs2 3.9.1
- Cats 2.10.0

The method `getLastMessageIdAsync` used on the implementation of `Consumer#lastMessageId` has been deprecated in favor of `getLastMessageIdsAsync`, which returns a list of `TopicMessageId`, so we now filter by the topic name in the consumer (only works for single-topic consumers). More details here: https://github.com/apache/pulsar/pull/20040 

Also upgrading the Pulsar Docker image used for tests to 3.1.0, matching the client version.

----

closes #148 
closes #145
closes #143
closes #141
closes #140
closes #138
closes #137
closes #136
closes #135
closes #133
closes #130
closes #114
closes #108
